### PR TITLE
fix: set left margin for CheckBox and RadioButton to 3px

### DIFF
--- a/packages/pelagos/src/components/CheckBox.less
+++ b/packages/pelagos/src/components/CheckBox.less
@@ -3,7 +3,8 @@
 
 .CheckBox {
 	@layer-hover-effects();
-	margin-left: @sp-02;
+	// stylelint-disable-next-line @bluecateng/property-strict-value -- minimum space to fit focus ring
+	margin-left: 3px;
 
 	&--disabled {
 		color: var(--text-disabled);

--- a/packages/pelagos/src/components/RadioButton.less
+++ b/packages/pelagos/src/components/RadioButton.less
@@ -3,7 +3,8 @@
 
 .RadioButton {
 	@layer-hover-effects();
-	margin-left: @sp-02;
+	// stylelint-disable-next-line @bluecateng/property-strict-value -- minimum space to fit focus ring
+	margin-left: 3px;
 
 	& > input {
 		margin-right: @sp-08;


### PR DESCRIPTION
Avoids cutting off the focus ring.