### PR TITLE
fix: use a nested form inside dialogs

### DIFF
--- a/packages/pelagos/__tests__/components/Dialog-test.js
+++ b/packages/pelagos/__tests__/components/Dialog-test.js
@@ -72,7 +72,7 @@ describe('Dialog', () => {
 					<div />
 				</Dialog>
 			);
-			wrapper.find('Layer').simulate('submit', event);
+			wrapper.find('form').simulate('submit', event);
 			expect(onSubmit.mock.calls).toEqual([[]]);
 			expect(event.preventDefault.mock.calls).toEqual([[]]);
 		});

--- a/packages/pelagos/__tests__/components/__snapshots__/Dialog-test.js.snap
+++ b/packages/pelagos/__tests__/components/__snapshots__/Dialog-test.js.snap
@@ -85,36 +85,38 @@ exports[`Dialog rendering renders expected elements when onSubmit is set 1`] = `
   <Layer
     aria-labelledby="dialogTitle"
     aria-modal={true}
-    as="form"
     className="Dialog Dialog--md"
     id="test-dialog"
     level={1}
-    onSubmit={[Function]}
     role="dialog"
   >
-    <React.Fragment>
-      <div
-        className="Dialog__title"
-        id="dialogTitle"
-      >
-        Test
-      </div>
-      <div
-        className="TestClass Dialog__body"
-      >
-        This is a test
-      </div>
-      <div
-        className="Dialog__buttons"
-      >
-        <Button
-          id="a"
-          size="medium"
-          text="A"
-          type="tertiary"
-        />
-      </div>
-    </React.Fragment>
+    <form
+      onSubmit={[Function]}
+    >
+      <React.Fragment>
+        <div
+          className="Dialog__title"
+          id="dialogTitle"
+        >
+          Test
+        </div>
+        <div
+          className="TestClass Dialog__body"
+        >
+          This is a test
+        </div>
+        <div
+          className="Dialog__buttons"
+        >
+          <Button
+            id="a"
+            size="medium"
+            text="A"
+            type="tertiary"
+          />
+        </div>
+      </React.Fragment>
+    </form>
   </Layer>
 </div>
 `;

--- a/packages/pelagos/src/components/Dialog.js
+++ b/packages/pelagos/src/components/Dialog.js
@@ -43,31 +43,16 @@ const Dialog = ({id, className, title, role, size, stretch, initialFocus, childr
 	const fullClassName = `Dialog Dialog--${size}${stretch ? ' Dialog--stretch' : ''}${className ? ` ${className}` : ''}`;
 	return (
 		<div className="Dialog__backdrop">
-			{onSubmit ? (
-				<Layer
-					as="form"
-					id={id}
-					className={fullClassName}
-					level={1}
-					role={role}
-					aria-modal
-					aria-labelledby="dialogTitle"
-					ref={element}
-					onSubmit={handleSubmit}>
-					{content}
-				</Layer>
-			) : (
-				<Layer
-					id={id}
-					className={fullClassName}
-					level={1}
-					role={role}
-					aria-modal
-					aria-labelledby="dialogTitle"
-					ref={element}>
-					{content}
-				</Layer>
-			)}
+			<Layer
+				id={id}
+				className={fullClassName}
+				level={1}
+				role={role}
+				aria-modal
+				aria-labelledby="dialogTitle"
+				ref={element}>
+				{onSubmit ? <form onSubmit={handleSubmit}>{content}</form> : content}
+			</Layer>
 		</div>
 	);
 };

--- a/packages/pelagos/src/components/Dialog.stories.js
+++ b/packages/pelagos/src/components/Dialog.stories.js
@@ -40,6 +40,20 @@ export const Default = {
 	},
 };
 
+export const WithForm = {
+	args: {
+		title: 'Title',
+		children: [
+			<div key="body">
+				<p>{body}</p>
+			</div>,
+			<div key="buttons">
+				<Button text="Button" type="primary" />
+			</div>,
+		],
+	},
+};
+
 const WiredComponent = () => {
 	const [visible, setVisible] = useState(false);
 	const show = useCallback(() => setVisible(true), []);


### PR DESCRIPTION
Using a different role in a form was flagged as a "best practice" issue by axe.