### PR TITLE
fix: use combobox role for Select

### DIFF
--- a/packages/pelagos/__tests__/components/__snapshots__/Select-test.js.snap
+++ b/packages/pelagos/__tests__/components/__snapshots__/Select-test.js.snap
@@ -14,6 +14,7 @@ exports[`Select rendering renders expected elements 1`] = `
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -43,6 +44,7 @@ exports[`Select rendering renders expected elements when className is not set 1`
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -71,6 +73,7 @@ exports[`Select rendering renders expected elements when disabled is true 1`] = 
     disabled={true}
     id="test"
     onBlur={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -101,6 +104,7 @@ exports[`Select rendering renders expected elements when error is true 1`] = `
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -131,6 +135,7 @@ exports[`Select rendering renders expected elements when noLayer is true 1`] = `
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -160,6 +165,7 @@ exports[`Select rendering renders expected elements when open is true 1`] = `
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -227,6 +233,7 @@ exports[`Select rendering renders expected elements when options are booleans 1`
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div
@@ -256,6 +263,7 @@ exports[`Select rendering renders expected elements when value is not set 1`] = 
     onBlur={[Function]}
     onKeyDown={[Function]}
     onMouseDown={[Function]}
+    role="combobox"
     type="button"
   >
     <div

--- a/packages/pelagos/src/components/Select.js
+++ b/packages/pelagos/src/components/Select.js
@@ -207,6 +207,7 @@ const Select = ({
 				className={`Select__text${selected ? '' : ' Select__text--empty'}${className ? ` ${className}` : ''}`}
 				type="button"
 				disabled={disabled}
+				role="combobox"
 				aria-haspopup="listbox"
 				aria-expanded={open}
 				aria-owns={open ? listId : null}


### PR DESCRIPTION
Following the "Select-Only Combobox" example.
Fixes error reported by axe when the field is required.

https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/