### PR TITLE
fix: stretch the Dialog form

### DIFF
--- a/packages/pelagos/__tests__/components/__snapshots__/Dialog-test.js.snap
+++ b/packages/pelagos/__tests__/components/__snapshots__/Dialog-test.js.snap
@@ -91,6 +91,7 @@ exports[`Dialog rendering renders expected elements when onSubmit is set 1`] = `
     role="dialog"
   >
     <form
+      className="Dialog__form"
       onSubmit={[Function]}
     >
       <React.Fragment>

--- a/packages/pelagos/src/components/Dialog.js
+++ b/packages/pelagos/src/components/Dialog.js
@@ -51,7 +51,13 @@ const Dialog = ({id, className, title, role, size, stretch, initialFocus, childr
 				aria-modal
 				aria-labelledby="dialogTitle"
 				ref={element}>
-				{onSubmit ? <form onSubmit={handleSubmit}>{content}</form> : content}
+				{onSubmit ? (
+					<form className="Dialog__form" onSubmit={handleSubmit}>
+						{content}
+					</form>
+				) : (
+					content
+				)}
 			</Layer>
 		</div>
 	);

--- a/packages/pelagos/src/components/Dialog.less
+++ b/packages/pelagos/src/components/Dialog.less
@@ -106,6 +106,10 @@
 			height: 100%;
 		}
 
+		&__form {
+			flex: 1;
+		}
+
 		&__title {
 			@heading-03();
 			@ellipsis();


### PR DESCRIPTION
Fix incorrect form height when the dialog is taller than the form contents.