### PR TITLE
fix: add resize listeners in pop-up positioning hooks

### DIFF
--- a/packages/pelagos/__tests__/hooks/useMenuHandler-test.js
+++ b/packages/pelagos/__tests__/hooks/useMenuHandler-test.js
@@ -8,6 +8,7 @@ jest.unmock('../../src/hooks/useMenuHandler');
 const anyFunction = expect.any(Function);
 
 global.document = {addEventListener: jest.fn(), removeEventListener: jest.fn()};
+global.window = {addEventListener: jest.fn(), removeEventListener: jest.fn()};
 
 describe('useMenuHandler', () => {
 	describe('handleButtonKeyDown', () => {
@@ -405,6 +406,7 @@ describe('useMenuHandler', () => {
 			const remove = useLayoutEffect.mock.calls[0][0]();
 			expect(getAttribute.mock.calls).toEqual([['role'], ['aria-disabled']]);
 			expect(document.addEventListener.mock.calls).toEqual([['scroll', anyFunction, {passive: true, capture: true}]]);
+			expect(window.addEventListener.mock.calls).toEqual([['resize', anyFunction, {passive: true, capture: true}]]);
 			expect(createFocusTrap.mock.calls).toEqual([
 				[menu, {initialFocus: firstChild, allowOutsideClick: anyFunction, onPostDeactivate: anyFunction}],
 			]);
@@ -430,8 +432,18 @@ describe('useMenuHandler', () => {
 				[button, menu],
 			]);
 
+			const onResize = window.addEventListener.mock.calls[0][1];
+			onResize();
+
+			expect(setPopUpPosition.mock.calls).toEqual([
+				[button, menu],
+				[button, menu],
+				[button, menu],
+			]);
+
 			remove();
 			expect(document.removeEventListener.mock.calls).toEqual(document.addEventListener.mock.calls);
+			expect(window.removeEventListener.mock.calls).toEqual(window.addEventListener.mock.calls);
 		});
 
 		it('does nothing when menuVisible is false', () => {

--- a/packages/pelagos/__tests__/hooks/useSelectPositioner-test.js
+++ b/packages/pelagos/__tests__/hooks/useSelectPositioner-test.js
@@ -6,9 +6,8 @@ jest.unmock('../../src/hooks/useSelectPositioner');
 
 const anyFunction = expect.any(Function);
 
-const addEventListener = jest.fn();
-const removeEventListener = jest.fn();
-global.document = {addEventListener, removeEventListener};
+global.document = {addEventListener: jest.fn(), removeEventListener: jest.fn()};
+global.window = {addEventListener: jest.fn(), removeEventListener: jest.fn()};
 global.innerHeight = 500;
 
 describe('useSelectPositioner', () => {
@@ -23,14 +22,20 @@ describe('useSelectPositioner', () => {
 		expect(useLayoutEffect.mock.calls[0]).toEqual([anyFunction, [buttonRef, popUpRef, true]]);
 		const remove = useLayoutEffect.mock.calls[0][0]();
 		expect(popUp.style).toEqual({top: '100px', left: '200px', width: '400px'});
-		expect(addEventListener.mock.calls).toEqual([['scroll', anyFunction, {passive: true, capture: true}]]);
+		expect(document.addEventListener.mock.calls).toEqual([['scroll', anyFunction, {passive: true, capture: true}]]);
+		expect(window.addEventListener.mock.calls).toEqual([['resize', anyFunction, {passive: true, capture: true}]]);
 
 		button.getBoundingClientRect = () => ({top: 330, bottom: 350, left: 200, width: 400});
-		addEventListener.mock.calls[0][1]();
+		document.addEventListener.mock.calls[0][1]();
 		expect(popUp.style).toEqual({top: '130px', left: '200px', width: '400px'});
 
+		button.getBoundingClientRect = () => ({top: 230, bottom: 250, left: 200, width: 400});
+		window.addEventListener.mock.calls[0][1]();
+		expect(popUp.style).toEqual({top: '250px', left: '200px', width: '400px'});
+
 		remove();
-		expect(removeEventListener.mock.calls).toEqual(addEventListener.mock.calls);
+		expect(document.removeEventListener.mock.calls).toEqual(document.addEventListener.mock.calls);
+		expect(window.removeEventListener.mock.calls).toEqual(window.addEventListener.mock.calls);
 	});
 
 	it('does not set the pop-up location when open is false', () => {

--- a/packages/pelagos/src/hooks/useAreaEditorPositioner.js
+++ b/packages/pelagos/src/hooks/useAreaEditorPositioner.js
@@ -37,6 +37,7 @@ const useAreaEditorPositioner = (ref, buttonId, onClose) =>
 		button.setAttribute('aria-controls', editor.id);
 
 		document.addEventListener('scroll', setEditorPosition, {passive: true, capture: true});
+		window.addEventListener('resize', setEditorPosition, {passive: true, capture: true});
 		const trap = createFocusTrap(editor, {
 			setReturnFocus: button,
 			allowOutsideClick: (event) => {
@@ -53,6 +54,7 @@ const useAreaEditorPositioner = (ref, buttonId, onClose) =>
 			button.removeAttribute('aria-expanded');
 			button.removeAttribute('aria-controls');
 			document.removeEventListener('scroll', setEditorPosition, {passive: true, capture: true});
+			window.removeEventListener('resize', setEditorPosition, {passive: true, capture: true});
 			trap.deactivate();
 		};
 	}, [ref, buttonId, onClose]);

--- a/packages/pelagos/src/hooks/useMenuHandler.js
+++ b/packages/pelagos/src/hooks/useMenuHandler.js
@@ -135,9 +135,11 @@ const useMenuHandler = (setPopUpPosition) => {
 			}));
 			trap.activate();
 			document.addEventListener('scroll', handleScroll, {passive: true, capture: true});
+			window.addEventListener('resize', handleScroll, {passive: true, capture: true});
 		}
 		return () => {
 			document.removeEventListener('scroll', handleScroll, {passive: true, capture: true});
+			window.removeEventListener('resize', handleScroll, {passive: true, capture: true});
 		};
 	}, [expanded, setPopUpPosition]);
 

--- a/packages/pelagos/src/hooks/useSelectPositioner.js
+++ b/packages/pelagos/src/hooks/useSelectPositioner.js
@@ -18,9 +18,11 @@ export default (open, buttonRef, popUpRef) =>
 		if (open) {
 			setPosition(button, popUp);
 			document.addEventListener('scroll', setPosition, {passive: true, capture: true});
+			window.addEventListener('resize', setPosition, {passive: true, capture: true});
 		}
 
 		return () => {
 			document.removeEventListener('scroll', setPosition, {passive: true, capture: true});
+			window.removeEventListener('resize', setPosition, {passive: true, capture: true});
 		};
 	}, [buttonRef, popUpRef, open]);


### PR DESCRIPTION
Without this change, resizing the window can cause the popup to appear in an incorrect position:
![Screenshot 2024-05-22 at 17 37 17](https://github.com/bluecatengineering/pelagos-packages/assets/25351536/2500cd5e-64ff-4634-8e92-2a1a2c8ec6b0)
