### PR TITLE
feat!: replace property mappers with names

### DIFF
--- a/packages/pelagos-charts/__tests__/charts/DonutChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/DonutChart-test.js
@@ -8,13 +8,12 @@ import identity from 'lodash-es/identity';
 import {addResizeObserver, Layer, useRandomId} from '@bluecateng/pelagos';
 
 import DonutChart from '../../src/charts/DonutChart';
-import {getDefaultClass} from '../../src/charts/Getters';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import getColorVariant from '../../src/charts/getColorVariant';
 import getColorClass from '../../src/charts/getColorClass';
 import setGradientParameters from '../../src/charts/setGradientParameters';
 
 jest.unmock('../../src/charts/DonutChart');
-jest.unmock('../../src/charts/Getters');
 
 jest.mock('d3-format', () => ({format: jest.fn((fmt) => jest.fn().mockReturnValue(`format-${fmt}`))}));
 
@@ -34,6 +33,7 @@ const createPaths = () => ({
 
 useRandomId.mockReturnValue('random-id');
 addResizeObserver.mockReturnValue('addResizeObserver');
+getDefaultClass.mockReturnValue('getDefaultClass');
 getColorClass.mockReturnValue('getColorClass');
 getColorVariant.mockReturnValue('getColorVariant');
 
@@ -147,8 +147,9 @@ describe('DonutChart', () => {
 
 			expect(sum.mock.calls[0][1](pieData[0])).toBe(3);
 
-			expect(paths.attr.mock.calls[0][1](arc1)).toBe('getColorClass');
+			expect(paths.attr.mock.calls[0][1](arc1)).toBe('getDefaultClass');
 			expect(getColorClass.mock.calls).toEqual([['fill', 'getColorVariant', 1, 1]]);
+			expect(getDefaultClass.mock.calls).toEqual([['b', null, 7, 'getColorClass']]);
 
 			expect(paths.attr.mock.calls[1][1](arc0)).toBe('d0');
 			expect(arcFn.mock.calls).toEqual([[arc0]]);

--- a/packages/pelagos-charts/__tests__/charts/LineChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/LineChart-test.js
@@ -16,15 +16,13 @@ import drawBottomAxis from '../../src/charts/drawBottomAxis';
 import drawGrid from '../../src/charts/drawGrid';
 import getColorClass from '../../src/charts/getColorClass';
 import getColorVariant from '../../src/charts/getColorVariant';
-import {getDefaultClass, getGroup, getValue} from '../../src/charts/Getters';
-import mappers from '../../src/charts/mappers';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import updateHint from '../../src/charts/updateHint';
 import getDomain from '../../src/charts/getDomain';
 import extractLineDataFromTidy from '../../src/charts/extractLineDataFromTidy';
 import drawLoadingGrid from '../../src/charts/drawLoadingGrid';
 
 jest.unmock('../../src/charts/LineChart');
-jest.unmock('../../src/charts/mappers');
 
 jest.mock('d3-shape', () => ({curveMonotoneX: 'curveMonotoneX', line: jest.fn()}));
 
@@ -42,9 +40,6 @@ jest.mock('../../src/charts/hintFormatters', () => ({
 }));
 
 const anyFunction = expect.any(Function);
-
-const getX = (d) => d.x;
-const getY = (d) => d.y;
 
 const createLineFn = () =>
 	Object.assign(jest.fn().mockReturnValue('line'), {
@@ -223,7 +218,7 @@ describe('LineChart', () => {
 					onDrag={onDrag}
 				/>
 			);
-			expect(extractLineDataFromTidy.mock.calls).toEqual([[data, undefined, getGroup, mappers.time, getValue]]);
+			expect(extractLineDataFromTidy.mock.calls).toEqual([[data, undefined, 'group', 'date', 'value']]);
 			expect(useLayoutEffect.mock.calls[0]).toEqual([
 				anyFunction,
 				[
@@ -612,8 +607,8 @@ describe('LineChart', () => {
 					curve="natural"
 					dataOptions={{groupFormatter: 'test-formatter', selectedGroups: ['a']}}
 					color={{pairing: {groupCount: 5, option: 2}}}
-					bottomAxis={{domain: 'bottom-domain', scaleType: 'log', title: 'Bottom title', mapper: getX}}
-					leftAxis={{domain: 'left-domain', scaleType: 'linear', title: 'Left title', mapper: getY}}
+					bottomAxis={{domain: 'bottom-domain', scaleType: 'log', title: 'Bottom title', mapsTo: 'x'}}
+					leftAxis={{domain: 'left-domain', scaleType: 'linear', title: 'Left title', mapsTo: 'y'}}
 					points={{filled: true, radius: 5}}
 					hint={{
 						enabled: false,
@@ -625,7 +620,7 @@ describe('LineChart', () => {
 					}}
 				/>
 			);
-			expect(extractLineDataFromTidy.mock.calls).toEqual([[data, ['a'], getGroup, getX, getY]]);
+			expect(extractLineDataFromTidy.mock.calls).toEqual([[data, ['a'], 'group', 'x', 'y']]);
 			expect(useLayoutEffect.mock.calls[0]).toEqual([
 				anyFunction,
 				[

--- a/packages/pelagos-charts/__tests__/charts/MeterChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/MeterChart-test.js
@@ -5,10 +5,10 @@ import {Layer, useRandomId} from '@bluecateng/pelagos';
 
 import MeterChart from '../../src/charts/MeterChart';
 import getColorClass from '../../src/charts/getColorClass';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import hintFormatters from '../../src/charts/hintFormatters';
 
 jest.unmock('../../src/charts/MeterChart');
-jest.unmock('../../src/charts/Getters');
 
 jest.mock('../../src/charts/hintFormatters', () => ({
 	linear: jest.fn().mockReturnValue('linear-hint'),
@@ -18,6 +18,7 @@ const anyFunction = expect.any(Function);
 
 useRandomId.mockReturnValue('random-id');
 getColorClass.mockReturnValue('getColorClass');
+getDefaultClass.mockReturnValue('getDefaultClass');
 
 describe('MeterChart', () => {
 	describe('rendering', () => {
@@ -25,6 +26,7 @@ describe('MeterChart', () => {
 			const wrapper = shallow(<MeterChart data={[{group: 'a', value: 35}]} />);
 			expect(wrapper.getElement()).toMatchSnapshot();
 			expect(getColorClass.mock.calls).toEqual([['bg', undefined, 1, 0]]);
+			expect(getDefaultClass.mock.calls).toEqual([['a', null, 35, 'getColorClass']]);
 		});
 
 		it('renders expected elements when optional properties are set', () => {

--- a/packages/pelagos-charts/__tests__/charts/ScatterChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/ScatterChart-test.js
@@ -14,14 +14,12 @@ import drawBottomAxis from '../../src/charts/drawBottomAxis';
 import drawGrid from '../../src/charts/drawGrid';
 import getColorClass from '../../src/charts/getColorClass';
 import getColorVariant from '../../src/charts/getColorVariant';
-import {getDefaultClass, getKey, getValue} from '../../src/charts/Getters';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import SingleHint from '../../src/charts/SingleHint';
 import drawLoadingGrid from '../../src/charts/drawLoadingGrid';
 import tickFormatters from '../../src/charts/tickFormatters';
 
 jest.unmock('../../src/charts/ScatterChart');
-jest.unmock('../../src/charts/Getters');
-jest.unmock('../../src/charts/mappers');
 
 jest.mock('../../src/charts/tickFormatters', () => ({
 	labels: null,
@@ -59,6 +57,7 @@ useRandomId.mockReturnValue('random-id');
 addResizeObserver.mockReturnValue('addResizeObserver');
 getColorClass.mockReturnValue('getColorClass');
 getColorVariant.mockReturnValue('getColorVariant');
+getDefaultClass.mockReturnValue('getDefaultClass');
 
 describe('ScatterChart', () => {
 	describe('rendering', () => {
@@ -215,7 +214,7 @@ describe('ScatterChart', () => {
 			]);
 			const dotsDatum = ['b', 1580533200000, 8];
 			tickFormatters.time.mockReturnValueOnce('time-tick-1').mockReturnValueOnce('time-tick-2');
-			expect(dots.attr.mock.calls[0][1](dotsDatum)).toBe('filled getColorClass getColorClass');
+			expect(dots.attr.mock.calls[0][1](dotsDatum)).toBe('filled getDefaultClass getDefaultClass');
 			expect(dots.attr.mock.calls[3][1](dotsDatum)).toBe(100);
 			expect(dots.attr.mock.calls[4][1](dotsDatum)).toBe(50);
 			expect(dots.attr.mock.calls[7][1](dotsDatum)).toBe('b, time-tick-1, 8');
@@ -274,6 +273,10 @@ describe('ScatterChart', () => {
 				['stroke', 'getColorVariant', 1, 1],
 				['fill', 'getColorVariant', 1, 1],
 			]);
+			expect(getDefaultClass.mock.calls).toEqual([
+				['b', 1580533200000, 8, 'getColorClass'],
+				['b', 1580533200000, 8, 'getColorClass'],
+			]);
 		});
 
 		it('adds an effect which renders the chart when alternate options are specified', () => {
@@ -303,8 +306,8 @@ describe('ScatterChart', () => {
 					data={data}
 					dataOptions={{groupFormatter: 'test-formatter', selectedGroups: ['a']}}
 					color={{pairing: {groupCount: 5, option: 2}}}
-					bottomAxis={{domain: 'bottom-domain', scaleType: 'log', title: 'Bottom title', mapper: getValue}}
-					leftAxis={{domain: 'left-domain', scaleType: 'labels', title: 'Left title', mapper: getKey}}
+					bottomAxis={{domain: 'bottom-domain', scaleType: 'log', title: 'Bottom title', mapsTo: 'value'}}
+					leftAxis={{domain: 'left-domain', scaleType: 'labels', title: 'Left title', mapsTo: 'key'}}
 					points={{fillOpacity: 0.8, filled: false, radius: 5}}
 					hint={{
 						enabled: false,
@@ -379,7 +382,7 @@ describe('ScatterChart', () => {
 				['aria-roledescription', 'point'],
 				['aria-label', anyFunction],
 			]);
-			expect(dots.attr.mock.calls[0][1](['a', 'foo', 8])).toBe('hollow getColorClass getColorClass');
+			expect(dots.attr.mock.calls[0][1](['a', 'foo', 8])).toBe('hollow getDefaultClass getDefaultClass');
 
 			expect(leftScale.mock.calls).toEqual([]);
 			expect(bottomScale.mock.calls).toEqual([]);

--- a/packages/pelagos-charts/__tests__/charts/SimpleBarChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/SimpleBarChart-test.js
@@ -5,7 +5,7 @@ import identity from 'lodash-es/identity';
 import {addResizeObserver, Layer, useRandomId} from '@bluecateng/pelagos';
 
 import SimpleBarChart from '../../src/charts/SimpleBarChart';
-import {getDefaultClass} from '../../src/charts/Getters';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import getPlotBottom from '../../src/charts/getPlotBottom';
 import createScale from '../../src/charts/createScale';
 import getTicks from '../../src/charts/getTicks';
@@ -18,8 +18,6 @@ import extendDomain from '../../src/charts/extendDomain';
 import drawLoadingGrid from '../../src/charts/drawLoadingGrid';
 
 jest.unmock('../../src/charts/SimpleBarChart');
-jest.unmock('../../src/charts/Getters');
-jest.unmock('../../src/charts/mappers');
 
 jest.mock('../../src/charts/hintFormatters', () => ({
 	labels: 'labels-hint',
@@ -40,6 +38,7 @@ global.innerWidth = 800;
 
 useRandomId.mockReturnValue('random-id');
 addResizeObserver.mockReturnValue('addResizeObserver');
+getDefaultClass.mockReturnValue('getDefaultClass');
 getColorClass.mockReturnValue('getColorClass');
 getColorVariant.mockReturnValue('getColorVariant');
 
@@ -195,7 +194,7 @@ describe('SimpleBarChart', () => {
 				['click', anyFunction],
 			]);
 
-			expect(barSelect.attr.mock.calls[0][1](['b'])).toBe('getColorClass');
+			expect(barSelect.attr.mock.calls[0][1](['b'])).toBe('getDefaultClass');
 			expect(barSelect.attr.mock.calls[1][1](['', 'foo', 5])).toBe('m56,140h48v-50h-48z');
 			expect(barSelect.attr.mock.calls[1][1](['', 'bar', 0])).toBe('m136,140h48v0h-48z');
 			expect(barSelect.attr.mock.calls[1][1](['', 'baz', -5])).toBe('m216,140h48v50h-48z');
@@ -230,6 +229,7 @@ describe('SimpleBarChart', () => {
 			expect(leftScale.mock.calls).toEqual([[0], [5], [-5]]);
 			expect(bottomScale.mock.calls).toEqual([['foo'], ['bar'], ['baz']]);
 			expect(getColorClass.mock.calls).toEqual([['fill', 'getColorVariant', 1, 1]]);
+			expect(getDefaultClass.mock.calls).toEqual([['b', undefined, undefined, 'getColorClass']]);
 		});
 
 		it('adds an effect which renders the chart when alternate options are specified', () => {
@@ -373,8 +373,8 @@ describe('SimpleBarChart', () => {
 						{group: 'a', key: 'bar', value: 1},
 						{group: 'b', key: 'foo', value: 5},
 					]}
-					bottomAxis={{scaleType: 'linear', mapper: (d) => d.value}}
-					leftAxis={{scaleType: 'labels', mapper: (d) => d.key}}
+					bottomAxis={{scaleType: 'linear', mapsTo: 'value'}}
+					leftAxis={{scaleType: 'labels', mapsTo: 'key'}}
 				/>
 			);
 			expect(useLayoutEffect.mock.calls[0]).toEqual([
@@ -484,8 +484,8 @@ describe('SimpleBarChart', () => {
 						{group: 'a', key: 'bar', value: -1},
 						{group: 'b', key: 'foo', value: 5},
 					]}
-					bottomAxis={{scaleType: 'linear', mapper: (d) => d.value}}
-					leftAxis={{scaleType: 'labels', mapper: (d) => d.key}}
+					bottomAxis={{scaleType: 'linear', mapsTo: 'value'}}
+					leftAxis={{scaleType: 'labels', mapsTo: 'key'}}
 				/>
 			);
 			expect(useLayoutEffect.mock.calls[0]).toEqual([

--- a/packages/pelagos-charts/__tests__/charts/StackedBarChart-test.js
+++ b/packages/pelagos-charts/__tests__/charts/StackedBarChart-test.js
@@ -7,8 +7,7 @@ import identity from 'lodash-es/identity';
 import {addResizeObserver, useRandomId} from '@bluecateng/pelagos';
 
 import StackedBarChart from '../../src/charts/StackedBarChart';
-import {getDefaultClass, getGroup, getValue} from '../../src/charts/Getters';
-import mappers from '../../src/charts/mappers';
+import getDefaultClass from '../../src/charts/getDefaultClass';
 import getColorVariant from '../../src/charts/getColorVariant';
 import getColorClass from '../../src/charts/getColorClass';
 import getPlotBottom from '../../src/charts/getPlotBottom';
@@ -24,7 +23,6 @@ import extractStackDataFromTidy from '../../src/charts/extractStackDataFromTidy'
 import drawLoadingGrid from '../../src/charts/drawLoadingGrid';
 
 jest.unmock('../../src/charts/StackedBarChart');
-jest.unmock('../../src/charts/mappers');
 
 jest.mock('../../src/charts/hintFormatters', () => ({
 	labels: 'labels-hint',
@@ -157,7 +155,7 @@ describe('StackedBarChart', () => {
 			select.mockReturnValueOnce(zero).mockReturnValueOnce(bars).mockReturnValueOnce(grid);
 			scaleQuantize.mockReturnValueOnce(quantize);
 			shallow(<StackedBarChart data={data} onClick={onClick} />);
-			expect(extractStackDataFromTidy.mock.calls).toEqual([[data, undefined, getGroup, mappers.labels, getValue]]);
+			expect(extractStackDataFromTidy.mock.calls).toEqual([[data, undefined, 'group', 'key', 'value']]);
 			expect(stackFn.keys.mock.calls).toEqual([[groupSet]]);
 			expect(stackFn.value.mock.calls).toEqual([[anyFunction]]);
 			expect(stackFn.order.mock.calls).toEqual([['stackOrderNone']]);
@@ -547,8 +545,8 @@ describe('StackedBarChart', () => {
 						{group: 'b', key: 'foo', value: 5},
 						{group: 'b', key: 'bar', value: null},
 					]}
-					bottomAxis={{scaleType: 'linear', mapper: (d) => d.value}}
-					leftAxis={{scaleType: 'labels', mapper: (d) => d.key}}
+					bottomAxis={{scaleType: 'linear', mapsTo: 'value'}}
+					leftAxis={{scaleType: 'labels', mapsTo: 'key'}}
 					onClick={onClick}
 				/>
 			);
@@ -742,8 +740,8 @@ describe('StackedBarChart', () => {
 						{group: 'b', key: 'foo', value: 5},
 						{group: 'b', key: 'bar', value: null},
 					]}
-					bottomAxis={{scaleType: 'linear', mapper: (d) => d.value}}
-					leftAxis={{scaleType: 'labels', mapper: (d) => d.key}}
+					bottomAxis={{scaleType: 'linear', mapsTo: 'value'}}
+					leftAxis={{scaleType: 'labels', mapsTo: 'key'}}
 				/>
 			);
 
@@ -868,7 +866,7 @@ describe('StackedBarChart', () => {
 					hint={{enabled: false, headerFormatter: 'test-header-formatter', valueFormatter: 'test-value-formatter'}}
 				/>
 			);
-			expect(extractStackDataFromTidy.mock.calls).toEqual([[data, ['a'], getGroup, mappers.labels, getValue]]);
+			expect(extractStackDataFromTidy.mock.calls).toEqual([[data, ['a'], 'group', 'key', 'value']]);
 
 			expect(useLayoutEffect.mock.calls[0]).toEqual([
 				anyFunction,

--- a/packages/pelagos-charts/__tests__/charts/__snapshots__/DonutChart-test.js.snap
+++ b/packages/pelagos-charts/__tests__/charts/__snapshots__/DonutChart-test.js.snap
@@ -34,7 +34,7 @@ exports[`DonutChart rendering renders expected elements 1`] = `
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div
@@ -70,7 +70,7 @@ exports[`DonutChart rendering renders expected elements when data loading is set
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div
@@ -123,7 +123,7 @@ exports[`DonutChart rendering renders expected elements when optional properties
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={
       [
         "a",

--- a/packages/pelagos-charts/__tests__/charts/__snapshots__/MeterChart-test.js.snap
+++ b/packages/pelagos-charts/__tests__/charts/__snapshots__/MeterChart-test.js.snap
@@ -31,7 +31,7 @@ exports[`MeterChart rendering renders expected elements 1`] = `
     >
       <div
         aria-label={null}
-        className="Chart__meterBar getColorClass"
+        className="Chart__meterBar getDefaultClass"
         data-index={0}
         id="random-id-0"
         onClick={null}
@@ -70,7 +70,7 @@ exports[`MeterChart rendering renders expected elements when optional properties
     >
       <div
         aria-label="b, linear-hint"
-        className="Chart__meterBar getColorClass clickable"
+        className="Chart__meterBar getDefaultClass clickable"
         data-index={0}
         id="random-id-0"
         onClick={[Function]}
@@ -132,7 +132,7 @@ exports[`MeterChart rendering renders expected elements when proportional is set
     >
       <div
         aria-label={null}
-        className="Chart__meterBar getColorClass"
+        className="Chart__meterBar getDefaultClass"
         data-index={0}
         id="random-id-0"
         onClick={null}
@@ -147,7 +147,7 @@ exports[`MeterChart rendering renders expected elements when proportional is set
       />
       <div
         aria-label={null}
-        className="Chart__meterBar getColorClass"
+        className="Chart__meterBar getDefaultClass"
         data-index={1}
         id="random-id-1"
         onClick={null}
@@ -162,7 +162,7 @@ exports[`MeterChart rendering renders expected elements when proportional is set
       />
       <div
         aria-label={null}
-        className="Chart__meterBar getColorClass"
+        className="Chart__meterBar getDefaultClass"
         data-index={2}
         id="random-id-2"
         onClick={null}
@@ -190,7 +190,44 @@ exports[`MeterChart rendering renders expected elements when proportional is set
     clickable={false}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={
+      [MockFunction] {
+        "calls": [
+          [
+            "Alpha",
+            null,
+            12,
+            "getColorClass",
+          ],
+          [
+            "Beta",
+            null,
+            15,
+            "getColorClass",
+          ],
+          [
+            "Gamma",
+            null,
+            6,
+            "getColorClass",
+          ],
+        ],
+        "results": [
+          {
+            "type": "return",
+            "value": "getDefaultClass",
+          },
+          {
+            "type": "return",
+            "value": "getDefaultClass",
+          },
+          {
+            "type": "return",
+            "value": "getDefaultClass",
+          },
+        ],
+      }
+    }
     groups={
       [
         "Alpha",
@@ -240,7 +277,7 @@ exports[`MeterChart rendering renders expected elements when status is set and v
     >
       <div
         aria-label={null}
-        className="Chart__meterBar Chart__meterDangerBg"
+        className="Chart__meterBar getDefaultClass"
         data-index={0}
         id="random-id-0"
         onClick={null}
@@ -304,7 +341,7 @@ exports[`MeterChart rendering renders expected elements when status is set and v
     >
       <div
         aria-label={null}
-        className="Chart__meterBar Chart__meterSuccessBg"
+        className="Chart__meterBar getDefaultClass"
         data-index={0}
         id="random-id-0"
         onClick={null}
@@ -368,7 +405,7 @@ exports[`MeterChart rendering renders expected elements when status is set and v
     >
       <div
         aria-label={null}
-        className="Chart__meterBar Chart__meterWarningBg"
+        className="Chart__meterBar getDefaultClass"
         data-index={0}
         id="random-id-0"
         onClick={null}

--- a/packages/pelagos-charts/__tests__/charts/__snapshots__/ScatterChart-test.js.snap
+++ b/packages/pelagos-charts/__tests__/charts/__snapshots__/ScatterChart-test.js.snap
@@ -31,7 +31,7 @@ exports[`ScatterChart rendering renders expected elements 1`] = `
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div
@@ -74,7 +74,7 @@ exports[`ScatterChart rendering renders expected elements when data loading is s
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div
@@ -114,7 +114,7 @@ exports[`ScatterChart rendering renders expected elements when optional properti
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div

--- a/packages/pelagos-charts/__tests__/charts/__snapshots__/SimpleBarChart-test.js.snap
+++ b/packages/pelagos-charts/__tests__/charts/__snapshots__/SimpleBarChart-test.js.snap
@@ -98,7 +98,7 @@ exports[`SimpleBarChart rendering renders expected elements when optional proper
     clickable={true}
     direction="horizontal"
     formatter={[Function]}
-    getBgClass={[Function]}
+    getBgClass={[MockFunction]}
     groups={[]}
   />
   <div

--- a/packages/pelagos-charts/__tests__/charts/extractLineDataFromTidy-test.js
+++ b/packages/pelagos-charts/__tests__/charts/extractLineDataFromTidy-test.js
@@ -2,10 +2,6 @@ import extractLineDataFromTidy from '../../src/charts/extractLineDataFromTidy';
 
 jest.unmock('../../src/charts/extractLineDataFromTidy');
 
-const getGroup = (d) => d.group;
-const getDate = (d) => d.date;
-const getValue = (d) => d.value;
-
 const data = [
 	{group: 'a', date: 1577854800000, value: 8},
 	{group: 'a', date: 1579064400000, value: 1},
@@ -17,7 +13,7 @@ const data = [
 
 describe('extractLineDataFromTidy', () => {
 	it('returns expected data', () => {
-		expect(extractLineDataFromTidy(data, null, getGroup, getDate, getValue)).toEqual({
+		expect(extractLineDataFromTidy(data, null, 'group', 'date', 'value')).toEqual({
 			groups: new Map([
 				['a', [8, 1, 3]],
 				['b', [5, null, 9]],
@@ -56,7 +52,7 @@ describe('extractLineDataFromTidy', () => {
 	});
 
 	it('returns expected data when selected is set', () => {
-		expect(extractLineDataFromTidy(data, ['b'], getGroup, getDate, getValue)).toEqual({
+		expect(extractLineDataFromTidy(data, ['b'], 'group', 'date', 'value')).toEqual({
 			groups: new Map([['b', [5, null, 9]]]),
 			groupIndex: new Map([
 				['a', 0],

--- a/packages/pelagos-charts/__tests__/charts/extractStackDataFromTidy-test.js
+++ b/packages/pelagos-charts/__tests__/charts/extractStackDataFromTidy-test.js
@@ -2,10 +2,6 @@ import extractStackDataFromTidy from '../../src/charts/extractStackDataFromTidy'
 
 jest.unmock('../../src/charts/extractStackDataFromTidy');
 
-const getGroup = (d) => d.group;
-const getKey = (d) => d.key;
-const getValue = (d) => d.value;
-
 const data = [
 	{group: 'a', key: 'foo', value: 8},
 	{group: 'a', key: 'bar', value: 1},
@@ -15,7 +11,7 @@ const data = [
 
 describe('extractStackDataFromTidy', () => {
 	it('returns expected data', () => {
-		expect(extractStackDataFromTidy(data, null, getGroup, getKey, getValue)).toEqual({
+		expect(extractStackDataFromTidy(data, null, 'group', 'key', 'value')).toEqual({
 			stackData: new Map([
 				[
 					'foo',
@@ -46,7 +42,7 @@ describe('extractStackDataFromTidy', () => {
 	});
 
 	it('returns expected data when selected is set', () => {
-		expect(extractStackDataFromTidy(data, ['b'], getGroup, getKey, getValue)).toEqual({
+		expect(extractStackDataFromTidy(data, ['b'], 'group', 'key', 'value')).toEqual({
 			stackData: new Map([['foo', new Map([['b', 5]])]]),
 			groupSet: new Set(['b']),
 			groupIndex: new Map([

--- a/packages/pelagos-charts/__tests__/charts/getDefaultClass-test.js
+++ b/packages/pelagos-charts/__tests__/charts/getDefaultClass-test.js
@@ -1,0 +1,9 @@
+import getDefaultClass from '../../src/charts/getDefaultClass';
+
+jest.unmock('../../src/charts/getDefaultClass');
+
+describe('getDefaultClass', () => {
+	it('returns expected value', () => {
+		expect(getDefaultClass(null, null, null, 'TestClass')).toBe('TestClass');
+	});
+});

--- a/packages/pelagos-charts/src/charts/ChartPropTypes.js
+++ b/packages/pelagos-charts/src/charts/ChartPropTypes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 export const dataPropType = PropTypes.shape({
 	format: PropTypes.oneOf(['tidy', 'columns', 'native']),
 	groupFormatter: PropTypes.func,
-	groupMapper: PropTypes.func,
+	groupMapsTo: PropTypes.string,
 	loading: PropTypes.bool,
 	selectedGroups: PropTypes.array,
 });
@@ -14,7 +14,7 @@ export const colorPropType = PropTypes.shape({
 
 export const axisPropType = PropTypes.shape({
 	domain: PropTypes.array,
-	mapper: PropTypes.func,
+	mapsTo: PropTypes.string,
 	scaleType: PropTypes.oneOf(['labels', 'time', 'linear', 'log']),
 	ticks: PropTypes.shape({formatter: PropTypes.func}),
 	title: PropTypes.string,

--- a/packages/pelagos-charts/src/charts/DonutChart.js
+++ b/packages/pelagos-charts/src/charts/DonutChart.js
@@ -8,7 +8,7 @@ import identity from 'lodash-es/identity';
 import {addResizeObserver, Layer, useRandomId} from '@bluecateng/pelagos';
 
 import {colorPropType, dataPropType, hintPropType, legendPropType} from './ChartPropTypes';
-import {getDefaultClass, getGroup, getValue} from './Getters';
+import getDefaultClass from './getDefaultClass';
 import getColorClass from './getColorClass';
 import getColorVariant from './getColorVariant';
 import useSetHintPosition from './useSetHintPosition';
@@ -46,12 +46,12 @@ const DonutChart = ({
 
 	const {
 		groupFormatter: dataGroupFormatter,
-		groupMapper: dataGroupMapper,
+		groupMapsTo: dataGroupMapsTo,
 		loading: dataLoading,
 		selectedGroups: dataSelectedGroups,
 	} = {
 		groupFormatter: identity,
-		groupMapper: getGroup,
+		groupMapsTo: 'group',
 		loading: false,
 		...dataOptions,
 	};
@@ -61,7 +61,7 @@ const DonutChart = ({
 		number: centerNumber,
 		numberFormatter: centerNumberFormatter,
 	} = {numberFormatter: siFormatter, ...center};
-	const {valueMapper: donutValueMapper} = {valueMapper: getValue, ...donut};
+	const {valueMapsTo: donutValueMapsTo} = {valueMapsTo: 'value', ...donut};
 	const {
 		alignment: legendAlignment,
 		clickable: legendClickable,
@@ -81,13 +81,13 @@ const DonutChart = ({
 			return {groupIndex: new Map(), empty: true};
 		}
 		const selectedSet = new Set(dataSelectedGroups);
-		const chartData = data.map((d) => [dataGroupMapper(d), donutValueMapper(d), d]);
+		const chartData = data.map((d) => [d[dataGroupMapsTo], d[donutValueMapsTo], d]);
 		const groupIndex = new Map(chartData.map((d, index) => [d[0], index]));
 		const filteredData = selectedSet.size === 0 ? chartData : chartData.filter((d) => selectedSet.has(d[0]));
 		const empty = sum(filteredData, getChartValue) === 0;
 		const arcs = empty ? null : pie().value(getChartValue).padAngle(0.01)(filteredData);
 		return {arcs, groupIndex, empty};
-	}, [data, dataGroupMapper, dataLoading, dataSelectedGroups, donutValueMapper]);
+	}, [data, dataGroupMapsTo, dataLoading, dataSelectedGroups, donutValueMapsTo]);
 
 	const ref = useRef(null);
 	const drawRef = useRef(null);
@@ -246,7 +246,7 @@ DonutChart.propTypes = {
 	dataOptions: dataPropType,
 	color: colorPropType,
 	center: PropTypes.shape({label: PropTypes.string, number: PropTypes.number, numberFormatter: PropTypes.func}),
-	donut: PropTypes.shape({valueMapper: PropTypes.func}),
+	donut: PropTypes.shape({valueMapsTo: PropTypes.string}),
 	legend: legendPropType,
 	hint: hintPropType,
 	getFillClass: PropTypes.func,

--- a/packages/pelagos-charts/src/charts/Getters.js
+++ b/packages/pelagos-charts/src/charts/Getters.js
@@ -1,3 +1,0 @@
-export const getGroup = (d) => d.group;
-export const getValue = (d) => d.value;
-export const getDefaultClass = (_0, _1, _2, dftClass) => dftClass;

--- a/packages/pelagos-charts/src/charts/Legend.js
+++ b/packages/pelagos-charts/src/charts/Legend.js
@@ -4,7 +4,7 @@ import identity from 'lodash-es/identity';
 import {useRandomId} from '@bluecateng/pelagos';
 
 import {colorPropType} from './ChartPropTypes';
-import {getDefaultClass} from './Getters';
+import getDefaultClass from './getDefaultClass';
 import getColorClass from './getColorClass';
 import getColorVariant from './getColorVariant';
 import './Chart.less';

--- a/packages/pelagos-charts/src/charts/LineChart.js
+++ b/packages/pelagos-charts/src/charts/LineChart.js
@@ -15,7 +15,7 @@ import {
 	pointsPropType,
 	legendPropType,
 } from './ChartPropTypes';
-import {getDefaultClass, getGroup} from './Getters';
+import getDefaultClass from './getDefaultClass';
 import extractLineDataFromTidy from './extractLineDataFromTidy';
 import extractLineDataFromColumns from './extractLineDataFromColumns';
 import getDomain from './getDomain';
@@ -28,7 +28,7 @@ import getTicks from './getTicks';
 import drawLeftAxis from './drawLeftAxis';
 import drawBottomAxis from './drawBottomAxis';
 import drawGrid from './drawGrid';
-import mappers from './mappers';
+import scaleProperties from './scaleProperties';
 import tickFormatters from './tickFormatters';
 import hintFormatters from './hintFormatters';
 import updateHint from './updateHint';
@@ -141,23 +141,23 @@ const LineChart = ({
 	const {
 		format: dataFormat,
 		groupFormatter: dataGroupFormatter,
-		groupMapper: dataGroupMapper,
+		groupMapsTo: dataGroupMapsTo,
 		loading: dataLoading,
 		selectedGroups: dataSelectedGroups,
 	} = {
 		format: 'tidy',
 		groupFormatter: identity,
-		groupMapper: getGroup,
+		groupMapsTo: 'group',
 		loading: false,
 		...dataOptions,
 	};
 	const dataExtract = dataExtractors[dataFormat];
 	const {groupCount: colorGroupCount, option: colorOption} = {groupCount: null, option: 1, ...color?.pairing};
 	const {domain: bottomDomain, scaleType: bottomScaleType, title: bottomTitle} = {scaleType: 'labels', ...bottomAxis};
-	const bottomMapper = bottomAxis?.mapper || mappers[bottomScaleType];
+	const bottomMapsTo = bottomAxis?.mapsTo || scaleProperties[bottomScaleType];
 	const {formatter: bottomTickFormatter} = {formatter: tickFormatters[bottomScaleType], ...bottomAxis?.ticks};
 	const {domain: leftDomain, scaleType: leftScaleType, title: leftTitle} = {scaleType: 'linear', ...leftAxis};
-	const leftMapper = leftAxis?.mapper || mappers[leftScaleType];
+	const leftMapsTo = leftAxis?.mapsTo || scaleProperties[leftScaleType];
 	const {formatter: leftTickFormatter} = {formatter: tickFormatters[leftScaleType], ...leftAxis?.ticks};
 	const {
 		enabled: pointsEnabled,
@@ -196,9 +196,9 @@ const LineChart = ({
 		const {groups, groupIndex, hintValues, leftList, bottomList, pointList} = dataExtract(
 			data,
 			dataSelectedGroups,
-			dataGroupMapper,
-			bottomMapper,
-			leftMapper
+			dataGroupMapsTo,
+			bottomMapsTo,
+			leftMapsTo
 		);
 		return {
 			groups,
@@ -211,15 +211,15 @@ const LineChart = ({
 		};
 	}, [
 		bottomDomain,
-		bottomMapper,
+		bottomMapsTo,
 		bottomScaleType,
 		data,
 		dataExtract,
-		dataGroupMapper,
+		dataGroupMapsTo,
 		dataLoading,
 		dataSelectedGroups,
 		leftDomain,
-		leftMapper,
+		leftMapsTo,
 		leftScaleType,
 	]);
 

--- a/packages/pelagos-charts/src/charts/LineChart.stories.js
+++ b/packages/pelagos-charts/src/charts/LineChart.stories.js
@@ -2,9 +2,6 @@ import {useState} from 'react';
 
 import LineChart from './LineChart';
 
-const getX = (d) => d.x;
-const getY = (d) => d.y;
-
 export default {
 	title: 'Experimental Charts/LineChart',
 	component: LineChart,
@@ -118,8 +115,8 @@ export const BothScalesLinear = {
 			{group: 'Gamma', x: 3, y: 12e3},
 			{group: 'Gamma', x: 4, y: 6e3},
 		],
-		bottomAxis: {scaleType: 'linear', mapper: getX},
-		leftAxis: {mapper: getY},
+		bottomAxis: {scaleType: 'linear', mapsTo: 'x'},
+		leftAxis: {mapsTo: 'y'},
 	},
 };
 
@@ -140,8 +137,8 @@ export const BothScalesLabels = {
 			{group: 'Gamma', x: 'c', y: 'One'},
 			{group: 'Gamma', x: 'd', y: 'Five'},
 		],
-		bottomAxis: {mapper: getX},
-		leftAxis: {scaleType: 'labels', mapper: getY},
+		bottomAxis: {mapsTo: 'x'},
+		leftAxis: {scaleType: 'labels', mapsTo: 'y'},
 		hint: {showTotal: false},
 	},
 };

--- a/packages/pelagos-charts/src/charts/MeterChart.js
+++ b/packages/pelagos-charts/src/charts/MeterChart.js
@@ -8,7 +8,7 @@ import WarningFilled from '@carbon/icons-react/es/WarningFilled';
 import ErrorFilled from '@carbon/icons-react/es/ErrorFilled';
 
 import {colorPropType, dataPropType, hintPropType, legendPropType} from './ChartPropTypes';
-import {getDefaultClass, getGroup, getValue} from './Getters';
+import getDefaultClass from './getDefaultClass';
 import legendDirections from './legendDirections';
 import Legend from './Legend';
 import getColorClass from './getColorClass';
@@ -56,11 +56,11 @@ const MeterChart = ({
 	id = useRandomId(id);
 	const {
 		groupFormatter: dataGroupFormatter,
-		groupMapper: dataGroupMapper,
+		groupMapsTo: dataGroupMapsTo,
 		selectedGroups: dataSelectedGroups,
 	} = {
 		groupFormatter: identity,
-		groupMapper: getGroup,
+		groupMapsTo: 'group',
 		...dataOptions,
 	};
 	const {groupCount: colorGroupCount, option: colorOption} = {groupCount: null, option: 1, ...color?.pairing};
@@ -70,8 +70,8 @@ const MeterChart = ({
 		proportional: meterProportional,
 		showLabels: meterShowLabels,
 		status: meterStatus,
-		valueMapper: meterValueMapper,
-	} = {height: 8, showLabels: true, valueMapper: getValue, ...meter};
+		valueMapsTo: meterValueMapsTo,
+	} = {height: 8, showLabels: true, valueMapsTo: 'value', ...meter};
 	const {
 		total: proportionalTotal,
 		unit: proportionalUnit,
@@ -104,11 +104,11 @@ const MeterChart = ({
 		groupIndex: stateGroupIndex,
 	} = useMemo(() => {
 		const selectedSet = new Set(dataSelectedGroups);
-		const chartData = data.map((d) => [dataGroupMapper(d), meterValueMapper(d), d]);
+		const chartData = data.map((d) => [d[dataGroupMapsTo], d[meterValueMapsTo], d]);
 		const groupIndex = new Map(chartData.map((d, index) => [d[0], index]));
 		const filteredData = selectedSet.size === 0 ? chartData : chartData.filter((d) => selectedSet.has(d[0]));
 		return {groupIndex, data: filteredData, total: sum(filteredData, getChartValue)};
-	}, [data, dataGroupMapper, dataSelectedGroups, meterValueMapper]);
+	}, [data, dataGroupMapsTo, dataSelectedGroups, meterValueMapsTo]);
 
 	const ref = useRef(null);
 	const hintRef = useRef(null);
@@ -254,7 +254,7 @@ MeterChart.propTypes = {
 				danger: PropTypes.number.isRequired,
 			}),
 		}),
-		valueMapper: PropTypes.func,
+		valueMapsTo: PropTypes.string,
 	}),
 	legend: legendPropType,
 	hint: hintPropType,

--- a/packages/pelagos-charts/src/charts/StackedBarChart.js
+++ b/packages/pelagos-charts/src/charts/StackedBarChart.js
@@ -21,10 +21,10 @@ import {addResizeObserver, useRandomId} from '@bluecateng/pelagos';
 import 'core-js/actual/array/to-reversed';
 
 import {axisPropType, colorPropType, dataPropType, hintPropType, legendPropType} from './ChartPropTypes';
-import {getDefaultClass, getGroup} from './Getters';
+import getDefaultClass from './getDefaultClass';
 import extractStackDataFromTidy from './extractStackDataFromTidy';
 import extractStackDataFromColumns from './extractStackDataFromColumns';
-import mappers from './mappers';
+import scaleProperties from './scaleProperties';
 import tickFormatters from './tickFormatters';
 import hintFormatters from './hintFormatters';
 import extendDomain from './extendDomain';
@@ -103,13 +103,13 @@ const StackedBarChart = ({
 	const {
 		format: dataFormat,
 		groupFormatter: dataGroupFormatter,
-		groupMapper: dataGroupMapper,
+		groupMapsTo: dataGroupMapsTo,
 		loading: dataLoading,
 		selectedGroups: dataSelectedGroups,
 	} = {
 		format: 'tidy',
 		groupFormatter: identity,
-		groupMapper: getGroup,
+		groupMapsTo: 'group',
 		loading: false,
 		...dataOptions,
 	};
@@ -117,10 +117,10 @@ const StackedBarChart = ({
 	const {order: stackOrder, offset: stackOffset} = {order: 'none', offset: 'none', ...stack};
 	const {groupCount: colorGroupCount, option: colorOption} = {groupCount: null, option: 1, ...color?.pairing};
 	const {domain: bottomDomain, scaleType: bottomScaleType, title: bottomTitle} = {scaleType: 'labels', ...bottomAxis};
-	const bottomMapper = bottomAxis?.mapper || mappers[bottomScaleType];
+	const bottomMapsTo = bottomAxis?.mapsTo || scaleProperties[bottomScaleType];
 	const {formatter: bottomTickFormatter} = {formatter: tickFormatters[bottomScaleType], ...bottomAxis?.ticks};
 	const {domain: leftDomain, scaleType: leftScaleType, title: leftTitle} = {scaleType: 'linear', ...leftAxis};
-	const leftMapper = leftAxis?.mapper || mappers[leftScaleType];
+	const leftMapsTo = leftAxis?.mapsTo || scaleProperties[leftScaleType];
 	const {formatter: leftTickFormatter} = {formatter: tickFormatters[leftScaleType], ...leftAxis?.ticks};
 	const vertical = bottomScaleType === 'labels';
 	const {
@@ -155,9 +155,9 @@ const StackedBarChart = ({
 		const {stackData, groupSet, groupIndex, hintValues, labelSet} = dataExtract(
 			data,
 			dataSelectedGroups,
-			dataGroupMapper,
-			vertical ? bottomMapper : leftMapper,
-			vertical ? leftMapper : bottomMapper
+			dataGroupMapsTo,
+			vertical ? bottomMapsTo : leftMapsTo,
+			vertical ? leftMapsTo : bottomMapsTo
 		);
 		const series = d3Stack()
 			.keys(groupSet)
@@ -174,14 +174,14 @@ const StackedBarChart = ({
 		};
 	}, [
 		bottomDomain,
-		bottomMapper,
+		bottomMapsTo,
 		data,
 		dataExtract,
-		dataGroupMapper,
+		dataGroupMapsTo,
 		dataLoading,
 		dataSelectedGroups,
 		leftDomain,
-		leftMapper,
+		leftMapsTo,
 		stackOffset,
 		stackOrder,
 		vertical,

--- a/packages/pelagos-charts/src/charts/extractLineDataFromTidy.js
+++ b/packages/pelagos-charts/src/charts/extractLineDataFromTidy.js
@@ -1,4 +1,4 @@
-export default (data, selected, getGroup, getBottomValue, getLeftValue) => {
+export default (data, selected, groupMapsTo, bottomMapsTo, leftMapsTo) => {
 	const selectedSet = new Set(selected);
 	const allSelected = selectedSet.size === 0;
 	const bottomSet = new Set();
@@ -8,13 +8,13 @@ export default (data, selected, getGroup, getBottomValue, getLeftValue) => {
 	const hintValues = new Map();
 	const pointList = [];
 	for (const d of data) {
-		const group = getGroup(d);
+		const group = d[groupMapsTo];
 		if (!groupIndex.has(group)) {
 			groupIndex.set(group, groupIndex.size);
 		}
 		if (allSelected || selectedSet.has(group)) {
-			const bottomValue = getBottomValue(d);
-			const leftValue = getLeftValue(d);
+			const bottomValue = d[bottomMapsTo];
+			const leftValue = d[leftMapsTo];
 			bottomSet.add(bottomValue);
 			if (leftValue !== null) {
 				leftSet.add(leftValue);

--- a/packages/pelagos-charts/src/charts/extractStackDataFromTidy.js
+++ b/packages/pelagos-charts/src/charts/extractStackDataFromTidy.js
@@ -1,4 +1,4 @@
-export default (data, selected, getGroup, getLabel, getValue) => {
+export default (data, selected, groupMapsTo, labelMapsTo, valueMapsTo) => {
 	const selectedSet = new Set(selected);
 	const allSelected = selectedSet.size === 0;
 	const groupSet = new Set();
@@ -7,15 +7,15 @@ export default (data, selected, getGroup, getLabel, getValue) => {
 	const groupIndex = new Map();
 	const hintValues = new Map();
 	for (const d of data) {
-		const group = getGroup(d);
+		const group = d[groupMapsTo];
 		if (!groupIndex.has(group)) {
 			groupIndex.set(group, groupIndex.size);
 		}
 		if (allSelected || selectedSet.has(group)) {
-			const value = getValue(d);
+			const value = d[valueMapsTo];
 			groupSet.add(group);
 			if (value !== null) {
-				const label = getLabel(d);
+				const label = d[labelMapsTo];
 				labelSet.add(label);
 				const hintValue = [group, value];
 				const hintList = hintValues.get(label);

--- a/packages/pelagos-charts/src/charts/getDefaultClass.js
+++ b/packages/pelagos-charts/src/charts/getDefaultClass.js
@@ -1,0 +1,1 @@
+export default (_0, _1, _2, dftClass) => dftClass;

--- a/packages/pelagos-charts/src/charts/mappers.js
+++ b/packages/pelagos-charts/src/charts/mappers.js
@@ -1,8 +1,0 @@
-import {getValue} from './Getters';
-
-export default {
-	labels: (d) => d.key,
-	linear: getValue,
-	log: getValue,
-	time: (d) => d.date,
-};

--- a/packages/pelagos-charts/src/charts/scaleProperties.js
+++ b/packages/pelagos-charts/src/charts/scaleProperties.js
@@ -1,0 +1,6 @@
+export default {
+	labels: 'key',
+	linear: 'value',
+	log: 'value',
+	time: 'date',
+};


### PR DESCRIPTION
BREAKING-CHANGE: all previous mappers must be changed to property names: groupMapper -> groupMapsTo
mapper -> mapsTo
valueMapper -> valueMapsTo