### PR TITLE
fix: update initial focus selector in DateInput

### DIFF
--- a/packages/pelagos/__tests__/components/DateInput-test.js
+++ b/packages/pelagos/__tests__/components/DateInput-test.js
@@ -97,10 +97,7 @@ describe('DateInput', () => {
 			expect(popUp).toEqual({style: {top: '100px', left: '200px'}});
 			expect(activate.mock.calls).toEqual([[]]);
 			expect(createFocusTrap.mock.calls).toEqual([
-				[
-					popUp,
-					{initialFocus: '.Calendar [aria-selected="true"]', allowOutsideClick: anyFunction, onDeactivate: anyFunction},
-				],
+				[popUp, {initialFocus: '.Calendar [tabindex="0"]', allowOutsideClick: anyFunction, onDeactivate: anyFunction}],
 			]);
 
 			const {allowOutsideClick, onDeactivate} = createFocusTrap.mock.calls[0][1];

--- a/packages/pelagos/src/components/DateInput.js
+++ b/packages/pelagos/src/components/DateInput.js
@@ -46,7 +46,7 @@ const DateInput = ({className, value, disabled, error, format, parse, onChange, 
 		popUp.style.left = `${left}px`;
 
 		const trap = createFocusTrap(popUp, {
-			initialFocus: '.Calendar [aria-selected="true"]',
+			initialFocus: '.Calendar [tabindex="0"]',
 			allowOutsideClick: (event) => {
 				if (event.type === 'click') {
 					trap.deactivate();


### PR DESCRIPTION
The changes in https://github.com/bluecatengineering/pelagos-packages/pull/227/files replaced `[aria-selected="true"]` with `[tabindex="0"]` in `Calendar.js`.

Without this change to `DateInput`, I am seeing the following error when opening the calendar pop-up:
```
focus-trap.esm.js:280 Uncaught Error: `initialFocus` as selector refers to no known node
    at d (focus-trap.esm.js:280:15)
    at h (focus-trap.esm.js:286:16)
    at focus-trap.esm.js:746:16
```