### PR TITLE
fix: handle mouse events on calendar table cell spans

### DIFF
--- a/packages/pelagos/__tests__/components/Calendar-test.js
+++ b/packages/pelagos/__tests__/components/Calendar-test.js
@@ -311,8 +311,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([new Date(2019, 8, 15), setFocused]).mockReturnValueOnce([1]);
 
 			const wrapper = shallow(<Calendar />);
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
-			wrapper.find('#random-id').simulate('mouseover', {target: {dataset: {time: '1567656000000'}}});
+			wrapper.find('#random-id').simulate('mouseover', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setFocused.mock.calls).toEqual([[new Date(2019, 8, 5)]]);
 		});
 
@@ -321,8 +324,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([new Date(2019, 8, 15), setFocused]).mockReturnValueOnce([null]);
 
 			const wrapper = shallow(<Calendar />);
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {}});
 
-			wrapper.find('#random-id').simulate('mouseover', {target: {dataset: {}}});
+			wrapper.find('#random-id').simulate('mouseover', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setFocused).not.toHaveBeenCalled();
 		});
 
@@ -331,8 +337,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([new Date(2019, 8, 15), setFocused]).mockReturnValueOnce([null]);
 
 			const wrapper = shallow(<Calendar />);
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {}});
 
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {}}});
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setFocused).not.toHaveBeenCalled();
 		});
 
@@ -342,8 +351,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([new Date(2019, 8, 15), setFocused]).mockReturnValueOnce([null]);
 
 			const wrapper = shallow(<Calendar onChange={onChange} />);
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {time: '1567656000000'}}});
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setFocused.mock.calls).toEqual([[new Date(2019, 8, 5)]]);
 			expect(onChange.mock.calls).toEqual([[1567656000000]]);
 		});
@@ -354,8 +366,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([new Date(2019, 8, 15), setFocused]).mockReturnValueOnce([null, setHighlighted]);
 
 			const wrapper = shallow(<Calendar value={[]} />);
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {time: '1567656000000'}}});
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setFocused.mock.calls).toEqual([[new Date(2019, 8, 5)]]);
 			expect(setHighlighted.mock.calls).toEqual([[anyFunction]]);
 			expect(setHighlighted.mock.calls[0][0](null)).toBe(1567656000000);
@@ -371,8 +386,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([focused, setFocused]).mockReturnValueOnce([highlighted, setHighlighted]);
 
 			const wrapper = shallow(<Calendar value={[]} onChange={onChange} />);
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {time: '1567656000000'}}});
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setHighlighted.mock.calls).toEqual([[anyFunction]]);
 			expect(setHighlighted.mock.calls[0][0](highlighted)).toBeNull();
 			expect(onChange.mock.calls).toEqual([[[1567656000000, highlighted]]]);
@@ -388,8 +406,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([focused, setFocused]).mockReturnValueOnce([highlighted, setHighlighted]);
 
 			const wrapper = shallow(<Calendar value={[]} onChange={onChange} />);
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {time: '1567656000000'}}});
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setHighlighted.mock.calls).toEqual([[anyFunction]]);
 			expect(setHighlighted.mock.calls[0][0](highlighted)).toBeNull();
 			expect(onChange.mock.calls).toEqual([[[highlighted, 1567656000000]]]);
@@ -407,8 +428,11 @@ describe('Calendar', () => {
 			useState.mockReturnValueOnce([focused, setFocused]).mockReturnValueOnce([highlighted, setHighlighted]);
 
 			const wrapper = shallow(<Calendar value={[startTime, endTime]} onChange={onChange} />);
-			wrapper.find('#random-id').simulate('mouseup', {target: {dataset: {time: '1567656000000'}}});
+			const closest = jest.fn();
+			closest.mockReturnValueOnce({dataset: {time: '1567656000000'}});
 
+			wrapper.find('#random-id').simulate('mouseup', {target: {closest}});
+			expect(closest.mock.calls).toEqual([['td']]);
 			expect(setHighlighted.mock.calls).toEqual([[anyFunction]]);
 			expect(setHighlighted.mock.calls[0][0](highlighted)).toBeNull();
 			expect(onChange.mock.calls).toEqual([

--- a/packages/pelagos/src/components/Calendar.js
+++ b/packages/pelagos/src/components/Calendar.js
@@ -232,7 +232,7 @@ const Calendar = forwardRef(({id, className, value, onChange, ...props}, ref) =>
 
 	const handleMouseOver = useCallback(
 		(event) => {
-			const time = event.target.dataset.time;
+			const time = event.target.closest('td')?.dataset.time;
 			if (time && highlighted) {
 				setFocused(new Date(+time));
 			}
@@ -242,7 +242,7 @@ const Calendar = forwardRef(({id, className, value, onChange, ...props}, ref) =>
 
 	const handleMouseUp = useCallback(
 		(event) => {
-			const time = event.target.dataset.time;
+			const time = event.target.closest('td')?.dataset.time;
 			if (time) {
 				setFocused(new Date(+time));
 				handleHighlight(+time);


### PR DESCRIPTION
- The new `<span />` elements within the `<td />` of `<Calendar />` can be the target of mouse events. Clicking them results in the day not being selected.
  - Fixed by using `event.target.closest('td')`