### PR TITLE
fix: improve remove handling in ListInput

### DIFF
--- a/packages/pelagos/__tests__/listInput/ListInput-test.js
+++ b/packages/pelagos/__tests__/listInput/ListInput-test.js
@@ -362,7 +362,7 @@ describe('ListInput', () => {
 			const item1 = {id: 1};
 			const onListChange = jest.fn();
 			const wrapper = shallow(<ListInput id="test" list={[item0, item1]} onListChange={onListChange} />);
-			wrapper.find('ListEntries').prop('onRemoveClick')(item0);
+			wrapper.find('ListEntries').prop('onRemoveClick')(item0, 0);
 			expect(onListChange.mock.calls).toEqual([[[item1]]]);
 		});
 

--- a/packages/pelagos/src/listInput/ListInput.js
+++ b/packages/pelagos/src/listInput/ListInput.js
@@ -143,7 +143,7 @@ const ListInput = ({
 	);
 
 	const handleRemoveClick = useCallback(
-		(item) => onListChange(list.filter((old) => old !== item)),
+		(item, index) => onListChange([...list.slice(0, index), ...list.slice(index + 1)]),
 		[list, onListChange]
 	);
 


### PR DESCRIPTION
Use `index` to remove the item from the list instead of filtering against the value of `list[index]`. This fixes issues when removing an item which has an equivalent value to other items in `list`.