### PR TITLE
fix: use padding rather than margin for the dialog body

### DIFF
--- a/packages/pelagos/src/components/Dialog.less
+++ b/packages/pelagos/src/components/Dialog.less
@@ -132,8 +132,7 @@
 		}
 
 		&__body {
-			padding: @sp-16 @sp-16 0;
-			margin-bottom: @sp-48;
+			padding: @sp-16 @sp-16 @sp-48;
 			flex: 1;
 			overflow: hidden;
 		}


### PR DESCRIPTION
To follow Carbon's implementation.