### PR TITLE
docs: remove custom alignment of sbdocs-wrapper

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -7,9 +7,6 @@
 .sbdocs, .sbdocs-title {
     font-family: Roboto, sans-serif !important;
 }
-.sbdocs.sbdocs-wrapper {
-    justify-content: flex-start;
-}
 .sb-story {
     align-items: flex-start;
 }


### PR DESCRIPTION
These screenshots were taken in chrome, at 100% zoom.

Current storybook:
<img width="1918" height="1053" alt="Screenshot 2025-09-04 at 11 00 00" src="https://github.com/user-attachments/assets/8b3edaa1-b4c7-46fb-a20c-0e287a4b604b" />
<img width="1920" height="1054" alt="Screenshot 2025-09-04 at 11 00 11" src="https://github.com/user-attachments/assets/a01060c6-7664-4743-a382-2372af563724" />

Using the change in this PR:
<img width="1919" height="1053" alt="Screenshot 2025-09-04 at 11 00 29" src="https://github.com/user-attachments/assets/ae4a772b-c2b0-4ddd-8fcd-526516057b93" />
<img width="1919" height="1055" alt="Screenshot 2025-09-04 at 11 00 36" src="https://github.com/user-attachments/assets/42b0ff09-2d83-4dfd-97af-ef3a363678b4" />
