### PR TITLE
fix: make list selector dialog columns scrollable above the medium breakpoint

### DIFF
--- a/packages/pelagos/src/components/ListSelectorDialog.less
+++ b/packages/pelagos/src/components/ListSelectorDialog.less
@@ -1,14 +1,9 @@
-@import '../../less/breakpoints';
 @import '../../less/spacing';
 
 @layer pelagos {
 	.ListSelectorDialog {
 		&__selector {
 			margin-top: 0;
-
-			.breakpoint(md, {
-				flex: none;
-			});
 		}
 
 		&__buttons {


### PR DESCRIPTION
### Before:
https://github.com/user-attachments/assets/40ea91fb-14cc-49dc-a385-888d89106673

### After:
https://github.com/user-attachments/assets/f6aaae71-8665-425e-9ecc-3fbc6f61bac8
