### PR TITLE
fix: use width: min-content in fixed columns table

### DIFF
--- a/packages/pelagos/src/table/Table.less
+++ b/packages/pelagos/src/table/Table.less
@@ -13,7 +13,7 @@
 		}
 
 		&--fixedColumns {
-			width: fit-content;
+			width: min-content;
 		}
 
 		&--left {


### PR DESCRIPTION
In Firefox fit-content is rendered incorrectly as 100% width.